### PR TITLE
Fix #3

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -41,7 +41,7 @@ DOMFuzzHelperObserver.prototype = {
   classDescription: "DOMFuzz helper observer",
   classID:          Components.ID("{73DD0F4A-B201-44A1-8C56-D1D72432B02A}"),
   contractID:       "@mozilla.org/commandlinehandler/general-startup;1?type=fuzzinject",
-  QueryInterface:   XPCOMUtils.generateQI([Ci.nsICommandLineHandler]),
+  QueryInterface:   ChromeUtils.generateQI([Ci.nsICommandLineHandler]),
 
   init() {
     // Register for any messages our API needs us to handle

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
 
   "applications": {
     "gecko": {
-      "id": "fuzzpriv@fuzzing.mozilla.org"
+      "id": "domfuzz@squarefree.com"
     }
   },
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 2,
+  "name": "DOMFuzz Helper",
+  "version": "4.0.0",
+
+  "description": "For fuzz-testing browsers",
+
+  "applications": {
+    "gecko": {
+      "id": "fuzzpriv@fuzzing.mozilla.org"
+    }
+  },
+
+  "background": {
+    "scripts": ["fuzzpriv.js", "browser-polyfill.min.js"]
+  },
+
+  "content_scripts": [
+    {
+      "matches": ["file:///*", "http://127.0.0.1/*", "http://localhost/*"],
+      "js": ["inject.js", "browser-polyfill.min.js"],
+      "run_at": "document_start"
+    }
+  ],
+
+  "web_accessible_resources": ["harnessui.html"]
+}


### PR DESCRIPTION
1543944320113	addons.xpi	WARN	Exception running bootstrap method startup on domfuzz@squarefree.com: TypeError: DOMFuzzHelperObserver.prototype.init is not a function(resource://gre/modules/addons/XPIProvider.jsm -> file:///home/kkuehl/Downloads/github/domfuzz/dom/extension/bootstrap.js:466:3) JS Stack trace: startup@bootstrap.js:466:3
callBootstrapMethod@XPIProvider.jsm:1606:20
startup@XPIProvider.jsm:1721:27
startup@XPIProvider.jsm:2168:39
callProvider@AddonManager.jsm:203:12
_startProvider@AddonManager.jsm:651:5
startup@AddonManager.jsm:804:9
startup@AddonManager.jsm:2774:5
observe@addonManager.js:66:9